### PR TITLE
fix(FEC-11855): V3- skip intro playlist - if click Next when 'Skip Intro' appears, it will be showing for next media and don't close

### DIFF
--- a/src/skip.js
+++ b/src/skip.js
@@ -127,7 +127,7 @@ class Skip extends BasePlugin {
   }
 
   reset(): void {
-    this._currentMode = Mode.OFF;
+    this._removeButton();
     this.eventManager.removeAll();
   }
 


### PR DESCRIPTION
### Description of the Changes

**issue:** the currentMode was not reset correctly on plugin reset() logic (because the guard on the removeButton method)
**fix:** reset the currentMode to be 'off' correctly

solves: FEC-11855

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
