### PR TITLE
fix(FEC-11856): Skip intro/outro - 'Watch Next' button are remaining visible, if set default outro endTime and seek till the end

### DIFF
--- a/src/components/skip/skip.js
+++ b/src/components/skip/skip.js
@@ -19,7 +19,8 @@ const {connect} = ui.redux;
  * @returns {Object} - mapped state to this component
  */
 const mapStateToProps = state => ({
-  playerSize: state.shell.playerSize
+  playerSize: state.shell.playerSize,
+  loading: state.loading.show
 });
 
 const COMPONENT_NAME = 'Skip';
@@ -33,7 +34,7 @@ const COMPONENT_NAME = 'Skip';
 @connect(mapStateToProps, bindActions(actions))
 class Skip extends Component {
   render(): React$Element<any> | void {
-    if (this.props.playerSize !== PLAYER_SIZE.TINY) {
+    if (this.props.playerSize !== PLAYER_SIZE.TINY && !this.props.loading) {
       return (
         <div tabIndex="0" aria-label={this.props.label} className={skipStyle.btnSkip} onClick={this.props.onClick}>
           <Text id={this.props.label} />

--- a/src/skip.js
+++ b/src/skip.js
@@ -40,16 +40,11 @@ class Skip extends BasePlugin {
   }
 
   loadMedia(): void {
+    this.eventManager.listen(this.player, this.player.Event.DURATION_CHANGE, () => this._setOutroData());
     this.eventManager.listenOnce(this.player, this.player.Event.FIRST_PLAYING, () => {
-      this._setIntroOutroData();
+      this._setIntroData();
       this._initListeners();
     });
-  }
-
-  _setIntroOutroData(): void {
-    const {intro, outro} = this.player.sources.metadata;
-    this._setIntroData(intro);
-    this._setOutroData(outro);
   }
 
   _initListeners() {
@@ -61,7 +56,8 @@ class Skip extends BasePlugin {
     }
   }
 
-  _setIntroData(intro: SkipPoint): void {
+  _setIntroData(): void {
+    const {intro} = this.player.sources.metadata;
     if (typeof intro?.endTime === 'number') {
       if (typeof intro?.startTime !== 'number') {
         intro.startTime = 0;
@@ -72,11 +68,11 @@ class Skip extends BasePlugin {
     }
   }
 
-  _setOutroData(outro: SkipPoint): void {
+  _setOutroData(): void {
+    const {outro} = this.player.sources.metadata;
     if (typeof outro?.startTime === 'number') {
       if (typeof outro?.endTime !== 'number' || outro?.endTime === -1) {
         outro.endTime = this.player.duration - 1;
-        this.eventManager.listen(this.player, this.player.Event.DURATION_CHANGE, () => (this._outro.endTime = this.player.duration - 1));
       }
       this._outro = {...outro};
     } else {

--- a/src/skip.js
+++ b/src/skip.js
@@ -75,7 +75,7 @@ class Skip extends BasePlugin {
   _setOutroData(outro: SkipPoint): void {
     if (typeof outro?.startTime === 'number') {
       if (typeof outro?.endTime !== 'number' || outro?.endTime === -1) {
-        outro.endTime = this.player.duration;
+        outro.endTime = this.player.duration - 1;
       }
       this._outro = {...outro};
     } else {

--- a/src/skip.js
+++ b/src/skip.js
@@ -76,6 +76,7 @@ class Skip extends BasePlugin {
     if (typeof outro?.startTime === 'number') {
       if (typeof outro?.endTime !== 'number' || outro?.endTime === -1) {
         outro.endTime = this.player.duration - 1;
+        this.eventManager.listen(this.player, this.player.Event.DURATION_CHANGE, () => (this._outro.endTime = this.player.duration - 1));
       }
       this._outro = {...outro};
     } else {


### PR DESCRIPTION
### Description of the Changes

**issue:** The media duration might change during the playing, Which sometimes causes a situation that intro.endTime 
      (which is the video duration by default) may be greater then player.duration returned during the _updateMode (which is 
      constantly running) 
     so the condition in _isInSkipPointRange method would always evaluate to true when playing ending.

**fix:**  set the default to duration - 1, to take distance from the sensitive area

in addition : (regardless of the original issue) hides the button when player is on loading state

solves: FEC-11856

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
