### PR TITLE
fix(FEC-13444): fix intro/outro when relevantTime is greater than video duration

### DIFF
--- a/src/skip.js
+++ b/src/skip.js
@@ -68,7 +68,7 @@ class Skip extends BasePlugin {
         intro.startTime = 0;
       }
       this._intro = {...intro};
-    } else if (typeof relativeTime === 'number' && relativeTime < this.player.duration) {
+    } else if (this._isValidRelativeTime(relativeTime)) {
       this._intro = {
         startTime: 0,
         endTime: relativeTime
@@ -86,7 +86,7 @@ class Skip extends BasePlugin {
         outro.endTime = this.player.duration - 1;
       }
       this._outro = {...outro};
-    } else if (typeof relativeTime === 'number' && relativeTime < this.player.duration) {
+    } else if (this._isValidRelativeTime(relativeTime)) {
       this._outro = {
         startTime: this.player.duration - relativeTime,
         endTime: this.player.duration - 1
@@ -94,6 +94,10 @@ class Skip extends BasePlugin {
     } else {
       this.logger.warn('the outro startTime must be set with type of number and be less than the video duration', outro);
     }
+  }
+
+  _isValidRelativeTime(relativeTime): boolean {
+    return typeof relativeTime === 'number' && relativeTime < this.player.duration;
   }
 
   _updateMode(mode: string, skipPoint: SkipPoint): void {

--- a/src/skip.js
+++ b/src/skip.js
@@ -68,13 +68,13 @@ class Skip extends BasePlugin {
         intro.startTime = 0;
       }
       this._intro = {...intro};
-    } else if (typeof relativeTime === 'number') {
+    } else if (typeof relativeTime === 'number' && relativeTime < this.player.duration) {
       this._intro = {
         startTime: 0,
         endTime: relativeTime
       };
     } else {
-      this.logger.warn('the intro endTime must be set and type of number', intro);
+      this.logger.warn('the intro relativeTime must be set with type of number and less than the video duration', intro);
     }
   }
 
@@ -86,13 +86,13 @@ class Skip extends BasePlugin {
         outro.endTime = this.player.duration - 1;
       }
       this._outro = {...outro};
-    } else if (typeof relativeTime === 'number') {
+    } else if (typeof relativeTime === 'number' && relativeTime < this.player.duration) {
       this._outro = {
         startTime: this.player.duration - relativeTime,
         endTime: this.player.duration - 1
       };
     } else {
-      this.logger.warn('the outro startTime must be set and type of number', outro);
+      this.logger.warn('the outro relativeTime must be set with type of number and less than the video duration', outro);
     }
   }
 

--- a/src/skip.js
+++ b/src/skip.js
@@ -74,7 +74,7 @@ class Skip extends BasePlugin {
         endTime: relativeTime
       };
     } else {
-      this.logger.warn('the intro relativeTime must be set with type of number and less than the video duration', intro);
+      this.logger.warn('the intro endTime must be set with type of number and be less than the video duration', intro);
     }
   }
 
@@ -92,7 +92,7 @@ class Skip extends BasePlugin {
         endTime: this.player.duration - 1
       };
     } else {
-      this.logger.warn('the outro relativeTime must be set with type of number and less than the video duration', outro);
+      this.logger.warn('the outro startTime must be set with type of number and be less than the video duration', outro);
     }
   }
 

--- a/src/skip.js
+++ b/src/skip.js
@@ -99,18 +99,18 @@ class Skip extends BasePlugin {
   _updateMode(mode: string, skipPoint: SkipPoint): void {
     if (this._currentMode === Mode.OFF || this._currentMode === mode) {
       if (this._isInSkipPointRange(skipPoint)) {
-        this._displayButton(mode);
+        this._displayButton(mode, skipPoint);
       } else {
         this._removeButton();
       }
     }
   }
 
-  _displayButton(mode) {
+  _displayButton(mode, skipPoint) {
     if (this._currentMode === Mode.OFF) {
       this._addButton(mode, 'InteractiveArea');
       setTimeout(() => {
-        this._relocateButton(mode);
+        this._relocateButton(mode, skipPoint);
       }, this.config.timeout * 1000);
     }
   }
@@ -134,9 +134,11 @@ class Skip extends BasePlugin {
     });
   }
 
-  _relocateButton(mode) {
+  _relocateButton(mode, skipPoint) {
     this._removeButton();
-    this._addButton(mode, 'BottomBar');
+    if (this._isInSkipPointRange(skipPoint)) {
+      this._addButton(mode, 'BottomBar');
+    }
   }
 
   _removeButton(): void {


### PR DESCRIPTION
### Description of the Changes

when `relevantTime` of outro or intro is greater than the video duration- do not render the button, per request.

Solves FEC-13444, FEC-13445, FEC-13346

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
