### PR TITLE
fix(FEC-13453): skip button is behind the dual screen

### DIFF
--- a/src/components/skip/skip.scss
+++ b/src/components/skip/skip.scss
@@ -11,6 +11,7 @@
   font-size: 16px;
   cursor: pointer;
   padding: 7px 10px;
+  z-index: 2;
 
   &.interactive-area-position {
     bottom: 0;


### PR DESCRIPTION
### Description of the Changes

add `z-index` to the skip button so it will show on top of dualscreen in both Show and Hide states.

Solves FEC-13453

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
